### PR TITLE
Add tapes/ai.js provider wrapper

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -10,27 +10,10 @@
 
 import * as readline from 'readline';
 import { streamText } from 'ai';
-import { createOpenAI } from '@ai-sdk/openai';
-import { createAnthropic } from '@ai-sdk/anthropic';
-import { createTapesFetch } from './tapes-fetch.js';
+import { createTapesProvider, config } from './tapes/ai.js';
 
-const TAPES_PROXY_URL = process.env.TAPES_PROXY_URL || 'http://localhost:8080';
-const PROVIDER = process.env.PROVIDER || 'openai';
-const MODEL = process.env.MODEL || (PROVIDER === 'anthropic' ? 'claude-sonnet-4-5-20250929' : 'gpt-4o-mini');
 const SESSION_ID = `chat-${Date.now()}`;
-
-// Create Tapes-wrapped fetch
-const tapesFetch = createTapesFetch({
-  proxyUrl: TAPES_PROXY_URL,
-  headers: { 'X-Tapes-Session': SESSION_ID },
-});
-
-// Create provider
-const provider = PROVIDER === 'anthropic'
-  ? createAnthropic({ fetch: tapesFetch, apiKey: process.env.ANTHROPIC_API_KEY })
-  : createOpenAI({ fetch: tapesFetch, apiKey: process.env.OPENAI_API_KEY });
-
-const model = provider(MODEL);
+const { model } = createTapesProvider({ sessionId: SESSION_ID });
 const messages = [];
 
 // CLI interface
@@ -43,8 +26,8 @@ console.log('╔═════════════════════�
 console.log('║          Tapes Chat (AI SDK Integration)               ║');
 console.log('╚════════════════════════════════════════════════════════╝');
 console.log(`\n📼 Session: ${SESSION_ID}`);
-console.log(`🤖 Model: ${MODEL}`);
-console.log(`🔗 Proxy: ${TAPES_PROXY_URL}`);
+console.log(`🤖 Model: ${config.model}`);
+console.log(`🔗 Proxy: ${config.proxyUrl}`);
 console.log('\nType your message (or "exit" to quit, "clear" to reset)\n');
 
 async function chat(userInput) {

--- a/index.js
+++ b/index.js
@@ -10,51 +10,12 @@
  *   3. Run: `npm run dev`
  */
 
-import { generateText, streamText } from 'ai';
-import { createOpenAI } from '@ai-sdk/openai';
-import { createAnthropic } from '@ai-sdk/anthropic';
-import { createTapesFetch } from './tapes-fetch.js';
-
-// Configuration
-const TAPES_PROXY_URL = process.env.TAPES_PROXY_URL || 'http://localhost:8080';
-const PROVIDER = process.env.PROVIDER || 'openai'; // 'openai' or 'anthropic'
-const DEBUG = process.env.DEBUG === 'true';
-
-// Create the Tapes-wrapped fetch
-const tapesFetch = createTapesFetch({
-  proxyUrl: TAPES_PROXY_URL,
-  debug: DEBUG,
-  headers: {
-    // Optional: Add session/trace identifiers
-    'X-Tapes-Session': `demo-${Date.now()}`,
-  },
-});
-
-// Create provider with custom fetch
-function createProvider() {
-  if (PROVIDER === 'anthropic') {
-    return createAnthropic({
-      fetch: tapesFetch,
-      // The API key is still sent to the proxy, which forwards to Anthropic
-      apiKey: process.env.ANTHROPIC_API_KEY,
-    });
-  }
-  
-  // Default to OpenAI
-  return createOpenAI({
-    fetch: tapesFetch,
-    apiKey: process.env.OPENAI_API_KEY,
-  });
-}
+import { generateText } from 'ai';
+import { model, config } from './tapes/ai.js';
 
 // Example 1: Simple text generation
 async function exampleGenerateText() {
   console.log('\n📝 Example 1: generateText()\n');
-  
-  const provider = createProvider();
-  const model = PROVIDER === 'anthropic' 
-    ? provider('claude-sonnet-4-5-20250929')
-    : provider('gpt-4o-mini');
 
   const { text, usage } = await generateText({
     model,
@@ -65,39 +26,9 @@ async function exampleGenerateText() {
   console.log('Usage:', usage);
 }
 
-// Example 2: Streaming response
-async function exampleStreamText() {
-  console.log('\n🌊 Example 2: streamText()\n');
-  
-  const provider = createProvider();
-  const model = PROVIDER === 'anthropic'
-    ? provider('claude-sonnet-4-5-20250929')
-    : provider('gpt-4o-mini');
-
-  const result = streamText({
-    model,
-    prompt: 'Write a haiku about debugging code.',
-  });
-  
-  process.stdout.write('Response: ');
-  for await (const chunk of result.textStream) {
-    process.stdout.write(chunk);
-  }
-  console.log('\n');
-  
-  // Get final usage after stream completes
-  const usage = await result.usage;
-  console.log('Usage:', usage);
-}
-
-// Example 3: Multi-turn conversation
+// Example 2: Multi-turn conversation
 async function exampleConversation() {
-  console.log('\n💬 Example 3: Multi-turn conversation\n');
-  
-  const provider = createProvider();
-  const model = PROVIDER === 'anthropic'
-    ? provider('claude-sonnet-4-5-20250929')
-    : provider('gpt-4o-mini');
+  console.log('\n💬 Example 2: Multi-turn conversation\n');
 
   const messages = [
     { role: 'user', content: 'My name is Alice.' },
@@ -129,13 +60,12 @@ async function main() {
   console.log('╔════════════════════════════════════════════════════════╗');
   console.log('║     Tapes + Vercel AI SDK Integration POC              ║');
   console.log('╚════════════════════════════════════════════════════════╝');
-  console.log(`\nProxy URL: ${TAPES_PROXY_URL}`);
-  console.log(`Provider: ${PROVIDER}`);
-  console.log(`Debug: ${DEBUG}`);
+  console.log(`\nProxy URL: ${config.proxyUrl}`);
+  console.log(`Provider: ${config.provider}`);
+  console.log(`Debug: ${config.debug}`);
   
   try {
     await exampleGenerateText();
-    await exampleStreamText();
     await exampleConversation();
     
     console.log('\n✅ All examples completed!');

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "POC: Vercel AI SDK integration with Tapes proxy",
   "type": "module",
   "scripts": {
-    "start": "node server.js",
+    "start": "node index.js && echo exit | node chat.js && node server.js",
     "dev": "node index.js",
-    "chat": "node chat.js"
+    "chat": "node chat.js",
+    "server": "node server.js"
   },
   "dependencies": {
     "ai": "^4.0.0",

--- a/tapes/ai.js
+++ b/tapes/ai.js
@@ -1,0 +1,95 @@
+/**
+ * Tapes AI Provider Wrapper
+ *
+ * Centralizes provider configuration so consumer files don't repeat
+ * proxy/fetch/model boilerplate.
+ *
+ * Exports:
+ *   createTapesProvider({ sessionId, ... }) — full customization
+ *   createSessionModel(sessionId)          — quick per-request model
+ *   provider / model / config              — pre-configured singletons
+ */
+
+import { createOpenAI } from '@ai-sdk/openai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createTapesFetch } from '../tapes-fetch.js';
+
+// ── Defaults ────────────────────────────────────────────────────────
+
+const DEFAULTS = {
+  proxyUrl: process.env.TAPES_PROXY_URL || 'http://localhost:8080',
+  provider: process.env.PROVIDER || 'openai',
+  model: process.env.MODEL,
+  debug: process.env.DEBUG === 'true',
+};
+
+function defaultModel(providerName) {
+  return DEFAULTS.model || (providerName === 'anthropic' ? 'claude-sonnet-4-5-20250929' : 'gpt-4o-mini');
+}
+
+// ── Factory: full customization ─────────────────────────────────────
+
+/**
+ * Create a Tapes-proxied provider and model.
+ *
+ * @param {Object} opts
+ * @param {string}  [opts.sessionId]  — X-Tapes-Session header value
+ * @param {string}  [opts.provider]   — 'openai' | 'anthropic' (default: env PROVIDER)
+ * @param {string}  [opts.model]      — model id (default: env MODEL or provider default)
+ * @param {boolean} [opts.debug]      — enable fetch debug logging
+ * @param {string}  [opts.proxyUrl]   — Tapes proxy URL
+ * @param {Record<string,string>} [opts.headers] — extra headers
+ * @returns {{ provider: Function, model: import('ai').LanguageModel }}
+ */
+export function createTapesProvider(opts = {}) {
+  const providerName = opts.provider ?? DEFAULTS.provider;
+  const modelId = opts.model ?? defaultModel(providerName);
+  const proxyUrl = opts.proxyUrl ?? DEFAULTS.proxyUrl;
+  const debug = opts.debug ?? DEFAULTS.debug;
+
+  const tapesFetch = createTapesFetch({
+    proxyUrl,
+    debug,
+    headers: {
+      ...(opts.sessionId ? { 'X-Tapes-Session': opts.sessionId } : {}),
+      ...opts.headers,
+    },
+  });
+
+  const aiProvider = providerName === 'anthropic'
+    ? createAnthropic({ fetch: tapesFetch, apiKey: process.env.ANTHROPIC_API_KEY })
+    : createOpenAI({ fetch: tapesFetch, apiKey: process.env.OPENAI_API_KEY });
+
+  return { provider: aiProvider, model: aiProvider(modelId) };
+}
+
+// ── Factory: session-only shortcut (for server.js per-request use) ──
+
+/**
+ * Returns an AI SDK model instance configured for a specific session.
+ * @param {string} sessionId
+ * @returns {import('ai').LanguageModel}
+ */
+export function createSessionModel(sessionId) {
+  return createTapesProvider({ sessionId }).model;
+}
+
+// ── Pre-configured singletons ───────────────────────────────────────
+
+const _default = createTapesProvider({
+  sessionId: `demo-${Date.now()}`,
+});
+
+/** Default provider function (based on PROVIDER env var) */
+export const provider = _default.provider;
+
+/** Default model instance (based on PROVIDER + MODEL env vars) */
+export const model = _default.model;
+
+/** Frozen config object for banner/logging */
+export const config = Object.freeze({
+  proxyUrl: DEFAULTS.proxyUrl,
+  provider: DEFAULTS.provider,
+  model: defaultModel(DEFAULTS.provider),
+  debug: DEFAULTS.debug,
+});


### PR DESCRIPTION
## Summary
- Adds `tapes/ai.js` module that centralizes Tapes proxy + provider configuration into reusable factories (`createTapesProvider`, `createSessionModel`) and pre-configured singletons
- Simplifies `server.js`, `chat.js`, and `index.js` by replacing ~20 lines of repeated boilerplate per file with 1-3 line imports
- Removes broken `streamText` example (Tapes proxy strips SSE delimiters)
- Updates README with new API docs, `npm start` smoke test workflow, and known limitations

## Test plan
- [x] `node index.js` — generateText and multi-turn conversation pass
- [x] `node chat.js` — CLI chat starts and exits cleanly
- [x] `node server.js` — web UI loads and chat works
- [x] Tapes proxy logs show `conversation stored` with correct sessions
- [x] `npm start` runs all three sequentially as smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)