### PR TITLE
Add retry/failover handling for Tapes proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,30 @@ The `npm start` command launches an Express server with a browser-based chat int
 | `MODEL` | `gpt-4o-mini` / `claude-sonnet-4-5-20250929` | Model to use |
 | `PORT` | `3000` | Web UI server port |
 | `DEBUG` | `false` | Enable debug logging |
+| `TAPES_RETRY_ATTEMPTS` | `3` | Max retry attempts for proxy requests |
+| `TAPES_FAILOVER` | `false` | Failover to direct provider URL on proxy failure |
 | `OPENAI_API_KEY` | - | OpenAI API key |
 | `ANTHROPIC_API_KEY` | - | Anthropic API key |
+
+### Retry & Failover
+
+Requests through the Tapes proxy automatically retry on network errors (`ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`) and HTTP 502/503/504 responses using exponential backoff.
+
+When `failover` is enabled and all proxy retries are exhausted, one final attempt is made directly to the LLM provider, bypassing the proxy. This keeps your app functional even when the Tapes proxy is down.
+
+```javascript
+const { model } = createTapesProvider({
+  retry: { maxAttempts: 5, initialDelayMs: 1000, maxDelayMs: 10000 },
+  failover: true,
+});
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `retry.maxAttempts` | `3` | Total attempts before giving up |
+| `retry.initialDelayMs` | `500` | First retry delay (doubles each attempt) |
+| `retry.maxDelayMs` | `5000` | Maximum delay between retries |
+| `failover` | `false` | Bypass proxy as a last resort |
 
 ### Custom Headers
 

--- a/tapes-fetch.js
+++ b/tapes-fetch.js
@@ -1,20 +1,31 @@
 /**
  * Tapes Proxy Fetch Wrapper
- * 
+ *
  * Creates a custom fetch function that routes AI SDK requests through
  * the Tapes proxy for observability and recording.
- * 
+ *
  * Usage:
  *   import { createTapesFetch } from './tapes-fetch.js';
- *   
+ *
  *   const tapesFetch = createTapesFetch({
  *     proxyUrl: 'http://localhost:8080',
  *     // Optional: headers to add to all requests
- *     headers: { 'X-Tapes-Session': 'my-session-id' }
+ *     headers: { 'X-Tapes-Session': 'my-session-id' },
+ *     // Optional: retry configuration
+ *     retry: { maxAttempts: 3, initialDelayMs: 500, maxDelayMs: 5000 },
+ *     // Optional: failover to direct URL when proxy is down
+ *     failover: true,
  *   });
- *   
+ *
  *   // Use with AI SDK provider
  *   const openai = createOpenAI({ fetch: tapesFetch });
+ */
+
+/**
+ * @typedef {Object} RetryConfig
+ * @property {number} [maxAttempts=3] - Maximum number of retry attempts
+ * @property {number} [initialDelayMs=500] - Initial delay between retries in ms
+ * @property {number} [maxDelayMs=5000] - Maximum delay between retries in ms
  */
 
 /**
@@ -22,23 +33,61 @@
  * @property {string} proxyUrl - The Tapes proxy URL (e.g., 'http://localhost:8080')
  * @property {Record<string, string>} [headers] - Additional headers to include
  * @property {boolean} [debug] - Enable debug logging
+ * @property {RetryConfig} [retry] - Retry configuration for failed requests
+ * @property {boolean} [failover] - When true, fall back to direct URL if all proxy retries fail
  */
+
+const RETRYABLE_NETWORK_ERRORS = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'fetch failed', 'UND_ERR_CONNECT_TIMEOUT'];
+const RETRYABLE_STATUS_CODES = [502, 503, 504];
+
+/**
+ * Returns whether an error is retryable (network error or server error).
+ * @param {Error|null} error
+ * @param {Response|null} response
+ * @returns {boolean}
+ */
+function isRetryable(error, response) {
+  if (error) {
+    const message = error.message || '';
+    const code = error.cause?.code || '';
+    return RETRYABLE_NETWORK_ERRORS.some(e => message.includes(e) || code.includes(e));
+  }
+  if (response) {
+    return RETRYABLE_STATUS_CODES.includes(response.status);
+  }
+  return false;
+}
+
+/**
+ * Sleep for a given number of milliseconds.
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 /**
  * Creates a fetch function that routes requests through the Tapes proxy.
- * 
+ *
  * The proxy URL replaces the base URL of the original request while
  * preserving the path and query parameters.
- * 
+ *
  * @param {TapesConfig} config
  * @returns {typeof fetch}
  */
 export function createTapesFetch(config) {
   const { proxyUrl, headers: extraHeaders = {}, debug = false } = config;
-  
+  const retryConfig = {
+    maxAttempts: config.retry?.maxAttempts ?? 3,
+    initialDelayMs: config.retry?.initialDelayMs ?? 500,
+    maxDelayMs: config.retry?.maxDelayMs ?? 5000,
+  };
+  const failover = config.failover ?? false;
+
   // Normalize proxy URL (remove trailing slash)
   const normalizedProxyUrl = proxyUrl.replace(/\/$/, '');
-  
+
   /**
    * Custom fetch that routes through Tapes proxy
    * @param {RequestInfo | URL} input
@@ -47,58 +96,108 @@ export function createTapesFetch(config) {
    */
   return async function tapesFetch(input, init) {
     // Parse the original URL
-    const originalUrl = typeof input === 'string' 
-      ? new URL(input) 
-      : input instanceof URL 
-        ? input 
+    const originalUrl = typeof input === 'string'
+      ? new URL(input)
+      : input instanceof URL
+        ? input
         : new URL(input.url);
-    
+
     // Build the proxied URL: proxy base + original path + query
     const proxiedUrl = new URL(
       originalUrl.pathname + originalUrl.search,
       normalizedProxyUrl
     );
-    
+
     if (debug) {
       console.log(`[tapes] Proxying: ${originalUrl.href} → ${proxiedUrl.href}`);
     }
-    
+
     // Merge headers
     const headers = new Headers(init?.headers);
-    
+
     // Add extra headers from config
     for (const [key, value] of Object.entries(extraHeaders)) {
       headers.set(key, value);
     }
-    
+
     // Forward the original host as a header (useful for multi-tenant proxies)
     headers.set('X-Tapes-Original-Host', originalUrl.host);
-    
-    // Make the request through the proxy
-    const response = await fetch(proxiedUrl.href, {
-      ...init,
-      headers,
-    });
-    
-    if (debug) {
-      console.log(`[tapes] Response: ${response.status} ${response.statusText}`);
+
+    const requestInit = { ...init, headers };
+
+    // Retry loop for proxy requests
+    let lastError = null;
+    let lastResponse = null;
+
+    for (let attempt = 0; attempt < retryConfig.maxAttempts; attempt++) {
+      try {
+        const response = await fetch(proxiedUrl.href, requestInit);
+
+        if (isRetryable(null, response) && attempt < retryConfig.maxAttempts - 1) {
+          const delay = Math.min(retryConfig.initialDelayMs * 2 ** attempt, retryConfig.maxDelayMs);
+          if (debug) {
+            console.log(`[tapes] Proxy returned ${response.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retryConfig.maxAttempts})`);
+          }
+          lastResponse = response;
+          await sleep(delay);
+          continue;
+        }
+
+        if (debug) {
+          console.log(`[tapes] Response: ${response.status} ${response.statusText}`);
+        }
+        return response;
+      } catch (error) {
+        lastError = error;
+        if (isRetryable(error, null) && attempt < retryConfig.maxAttempts - 1) {
+          const delay = Math.min(retryConfig.initialDelayMs * 2 ** attempt, retryConfig.maxDelayMs);
+          if (debug) {
+            console.log(`[tapes] Proxy request failed (${error.cause?.code || error.message}), retrying in ${delay}ms (attempt ${attempt + 1}/${retryConfig.maxAttempts})`);
+          }
+          await sleep(delay);
+          continue;
+        }
+      }
     }
 
-    return response;
+    // All proxy retries exhausted — try failover to direct URL
+    if (failover) {
+      if (debug) {
+        console.log(`[tapes] All proxy retries failed, failing over to direct: ${originalUrl.href}`);
+      }
+      try {
+        const directHeaders = new Headers(init?.headers);
+        // Don't add proxy-specific headers for direct requests
+        const response = await fetch(originalUrl.href, { ...init, headers: directHeaders });
+        if (debug) {
+          console.log(`[tapes] Failover response: ${response.status} ${response.statusText}`);
+        }
+        return response;
+      } catch (failoverError) {
+        if (debug) {
+          console.log(`[tapes] Failover also failed: ${failoverError.cause?.code || failoverError.message}`);
+        }
+        throw failoverError;
+      }
+    }
+
+    // No failover — throw the last error or return the last bad response
+    if (lastError) throw lastError;
+    return lastResponse;
   };
 }
 
 /**
  * Creates a fetch function for a specific provider through Tapes.
  * This is a convenience wrapper that sets up the proxy for common providers.
- * 
+ *
  * @param {'openai' | 'anthropic' | 'ollama'} provider
  * @param {Omit<TapesConfig, 'proxyUrl'> & { tapesUrl?: string }} config
  * @returns {typeof fetch}
  */
 export function createProviderFetch(provider, config = {}) {
   const tapesUrl = config.tapesUrl || 'http://localhost:8080';
-  
+
   return createTapesFetch({
     proxyUrl: tapesUrl,
     headers: {
@@ -106,6 +205,8 @@ export function createProviderFetch(provider, config = {}) {
       ...config.headers,
     },
     debug: config.debug,
+    retry: config.retry,
+    failover: config.failover,
   });
 }
 


### PR DESCRIPTION
## Summary

- Adds retry with exponential backoff to `tapes-fetch.js` for network errors (`ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`) and HTTP 502/503/504
- Optional `failover` mode bypasses the proxy as a last resort when all retries are exhausted, keeping the app functional even when the Tapes proxy is down
- Config flows through `tapes/ai.js` with env var support (`TAPES_RETRY_ATTEMPTS`, `TAPES_FAILOVER`)
- All retry/failover activity is logged when `debug: true`

## Changes

- **tapes-fetch.js** — retry loop with exponential backoff + direct-to-provider failover
- **tapes/ai.js** — threads `retry`/`failover` config from env vars through to fetch wrapper
- **README.md** — documents new config options, env vars, and behavior

## Test plan

- [ ] Run `node index.js` with Tapes proxy stopped — verify retries appear in debug mode then graceful failure (or failover if enabled)
- [ ] Run `node index.js` with Tapes proxy running — verify requests succeed with no retries
- [ ] Set `TAPES_FAILOVER=true` with proxy stopped — verify direct provider request succeeds

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)